### PR TITLE
Replace array utils with native functions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -84,12 +84,6 @@
       "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
       "dev": true
     },
-    "@types/d3-array": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-2.9.0.tgz",
-      "integrity": "sha512-sdBMGfNvLUkBypPMEhOcKcblTQfgHbqbYrUqRE31jOwdDHBJBxz4co2MDAq93S4Cp++phk4UiwoEg/1hK3xXAQ==",
-      "dev": true
-    },
     "@types/d3-hierarchy": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-2.0.0.tgz",
@@ -1427,14 +1421,6 @@
           "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
           "dev": true
         }
-      }
-    },
-    "d3-array": {
-      "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
-      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
-      "requires": {
-        "internmap": "^1.0.0"
       }
     },
     "d3-color": {
@@ -2850,11 +2836,6 @@
           }
         }
       }
-    },
-    "internmap": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
-      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw=="
     },
     "is-arguments": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
   "author": "Przemek Wiech",
   "license": "Apache 2.0",
   "devDependencies": {
-    "@types/d3-array": "^2.9.0",
     "@types/d3-hierarchy": "^2.0.0",
     "@types/d3-selection": "^2.0.0",
     "@types/d3-transition": "^2.0.0",
@@ -42,7 +41,6 @@
   },
   "dependencies": {
     "array-flat-polyfill": "^1.0.1",
-    "d3-array": "^2.12.1",
     "d3-flextree": "^2.1.1",
     "d3-hierarchy": "^2.0.0",
     "d3-selection": "^2.0.0",

--- a/src/composite-renderer.ts
+++ b/src/composite-renderer.ts
@@ -1,5 +1,4 @@
 import { HierarchyNode } from 'd3-hierarchy';
-import { max } from 'd3-array';
 import { TreeEntry, TreeNode } from './api';
 
 /**
@@ -34,10 +33,10 @@ export abstract class CompositeRenderer {
       }
 
       const depth = node.depth;
-      const maxIndiVSize = max([
+      const maxIndiVSize = Math.max(
         getIndiVSize(node.data, !!this.options.horizontal),
-        indiVSizePerDepth.get(depth)!,
-      ])!;
+        indiVSizePerDepth.get(depth) ?? 0,
+      );
       indiVSizePerDepth.set(depth, maxIndiVSize);
     });
 
@@ -71,7 +70,7 @@ export abstract class CompositeRenderer {
       const x =
         -node.width! / 2 + getIndiVSize(node, this.options.horizontal) / 2;
       const famYOffset = node.family
-        ? max([-getFamPositionHorizontal(node), 0])!
+        ? Math.max(-getFamPositionHorizontal(node), 0)
         : 0;
       const y =
         -(node.indi && node.spouse ? node.height! / 2 - node.indi.height! : 0) +
@@ -79,7 +78,7 @@ export abstract class CompositeRenderer {
       return [x, y];
     }
     const famXOffset = node.family
-      ? max([-getFamPositionVertical(node), 0])
+      ? Math.max(-getFamPositionVertical(node), 0)
       : 0;
     const x =
       -(node.indi && node.spouse ? node.width! / 2 - node.indi.width! : 0) +
@@ -158,7 +157,7 @@ function getHSize(node: TreeNode, horizontal: boolean): number {
   }
   const indiHSize =
     (node.indi ? node.indi.width! : 0) + (node.spouse ? node.spouse.width! : 0);
-  return max([indiHSize, node.family ? node.family.width! : 0])!;
+  return Math.max(indiHSize, node.family ? node.family.width! : 0);
 }
 
 function getFamVSize(node: TreeNode, horizontal: boolean): number {
@@ -171,15 +170,15 @@ function getFamVSize(node: TreeNode, horizontal: boolean): number {
 /** Returns the vertical size of individual boxes. */
 function getIndiVSize(node: TreeNode, horizontal: boolean): number {
   if (horizontal) {
-    return max([
+    return Math.max(
       node.indi ? node.indi.width! : 0,
       node.spouse ? node.spouse.width! : 0,
-    ])!;
+    );
   }
-  return max([
+  return Math.max(
     node.indi ? node.indi.height! : 0,
     node.spouse ? node.spouse.height! : 0,
-  ])!;
+  );
 }
 
 /** Returns the vertical size. */

--- a/src/detailed-renderer.ts
+++ b/src/detailed-renderer.ts
@@ -2,7 +2,6 @@ import { BaseType, select, Selection } from 'd3-selection';
 import { ChartColors } from '.';
 import { FamDetails, IndiDetails } from './data';
 import { formatDateOrRange } from './date-format';
-import { max } from 'd3-array';
 import 'd3-transition';
 import {
   Renderer,
@@ -139,22 +138,22 @@ export class DetailedRenderer extends CompositeRenderer implements Renderer {
     const indi = this.options.data.getIndi(id)!;
     const details = this.getIndiDetails(indi);
 
-    const height = max([
+    const height = Math.max(
       INDI_MIN_HEIGHT + details.length * 14,
       indi.getImageUrl() ? IMAGE_HEIGHT : 0,
-    ])!;
+    );
 
-    const maxDetailsWidth = max(
-      details.map((x) => getLength(x.text, 'details'))
-    )!;
+    const maxDetailsWidth = Math.max(
+      ...details.map((x) => getLength(x.text, 'details'))
+    );
     const width =
-      max([
+      Math.max(
         maxDetailsWidth + 22,
         getLength(indi.getFirstName() || '', 'name') + 8,
         getLength(indi.getLastName() || '', 'name') + 8,
         getLength(id, 'id') + 32,
         INDI_MIN_WIDTH,
-      ])! + (indi.getImageUrl() ? IMAGE_WIDTH : 0);
+      )! + (indi.getImageUrl() ? IMAGE_WIDTH : 0);
     return [width, height];
   }
 
@@ -162,11 +161,11 @@ export class DetailedRenderer extends CompositeRenderer implements Renderer {
     const fam = this.options.data.getFam(id)!;
     const details = this.getFamDetails(fam);
 
-    const height = max([10 + details.length * 14, FAM_MIN_HEIGHT])!;
-    const maxDetailsWidth = max(
-      details.map((x) => getLength(x.text, 'details'))
-    )!;
-    const width = max([maxDetailsWidth + 22, FAM_MIN_WIDTH])!;
+    const height = Math.max(10 + details.length * 14, FAM_MIN_HEIGHT);
+    const maxDetailsWidth = Math.max(
+      ...details.map((x) => getLength(x.text, 'details'))
+    );
+    const width = Math.max(maxDetailsWidth + 22, FAM_MIN_WIDTH);
     return [width, height];
   }
 
@@ -182,11 +181,11 @@ export class DetailedRenderer extends CompositeRenderer implements Renderer {
           const result: OffsetIndi[] = [];
           const famXOffset =
             !this.options.horizontal && node.data.family
-              ? max([-getFamPositionVertical(node.data), 0])!
+              ? Math.max(-getFamPositionVertical(node.data), 0)
               : 0;
           const famYOffset =
             this.options.horizontal && node.data.family
-              ? max([-getFamPositionHorizontal(node.data), 0])!
+              ? Math.max(-getFamPositionHorizontal(node.data), 0)
               : 0;
           if (node.data.indi) {
             result.push({
@@ -360,9 +359,9 @@ export class DetailedRenderer extends CompositeRenderer implements Renderer {
     if (this.options.horizontal) {
       return `translate(${
         (node.indi && node.indi.width) || node.spouse!.width
-      }, ${max([getFamPositionHorizontal(node), 0])})`;
+      }, ${Math.max(getFamPositionHorizontal(node), 0)})`;
     }
-    return `translate(${max([getFamPositionVertical(node), 0])}, ${
+    return `translate(${Math.max(getFamPositionVertical(node), 0)}, ${
       (node.indi && node.indi.height) || node.spouse!.height
     })`;
   }
@@ -459,7 +458,7 @@ export class DetailedRenderer extends CompositeRenderer implements Renderer {
       details.set(node.indi.id, detailsList);
     });
 
-    const maxDetails = max(Array.from(details.values(), (v) => v.length))!;
+    const maxDetails = Math.max(...Array.from(details.values(), (v) => v.length));
 
     // Render details.
     for (let i = 0; i < maxDetails; ++i) {
@@ -563,7 +562,7 @@ export class DetailedRenderer extends CompositeRenderer implements Renderer {
       const detailsList = this.getFamDetails(fam);
       details.set(famId, detailsList);
     });
-    const maxDetails = max(Array.from(details.values(), (v) => v.length))!;
+    const maxDetails = Math.max(...Array.from(details.values(), (v) => v.length));
 
     // Render details.
     for (let i = 0; i < maxDetails; ++i) {

--- a/src/fancy-chart.ts
+++ b/src/fancy-chart.ts
@@ -1,6 +1,5 @@
 import { BaseType, Selection } from 'd3-selection';
 import { HierarchyPointNode } from 'd3-hierarchy';
-import { min } from 'd3-array';
 import { Chart, ChartInfo, ChartOptions, Fam, Indi, TreeNode } from './api';
 import { ChartUtil, getChartInfo, linkId, ChartSizeInfo } from './chart-util';
 import { DUMMY_ROOT_NODE_ID, layOutDescendants } from './descendant-chart';
@@ -136,7 +135,7 @@ export class FancyChart<IndiT extends Indi, FamT extends Fam> implements Chart {
     );
 
     const minGeneration =
-      min(backgroundNodes, (node) => node.data.generation) || 0;
+      backgroundNodes.reduce((acc, node) => Math.min(acc, node.data.generation ?? 0), 0);
     const sizeFunction = (node: HierarchyPointNode<TreeNode>) =>
       280 - 180 / Math.sqrt(1 + node.data.generation! - minGeneration);
     {

--- a/src/kinship/renderer.ts
+++ b/src/kinship/renderer.ts
@@ -1,5 +1,4 @@
 import { HierarchyNode, HierarchyPointNode } from 'd3-hierarchy';
-import { max, min } from 'd3-array';
 import { ChartInfo, ChartOptions, TreeNode as BaseTreeNode } from '../api';
 import { TreeNode, LinkType, otherSideLinkType } from './api';
 import { ChartUtil, getChartInfo } from '../chart-util';
@@ -282,14 +281,17 @@ export class KinshipChartRenderer {
     childNodes: TreeNode[],
     isMin: boolean
   ): number {
-    const extremeFindingFunction = isMin ? min : max;
+    const extremeFindingFunction = isMin ? Math.min : Math.max;
     const dir = isMin ? -1 : 1;
     const childNodesSet = new Set(childNodes);
     return (
-      extremeFindingFunction(
-        parentNode.children!.filter((n) => childNodesSet.has(n.data)),
-        (n) => n.x + (dir * n.data.width!) / 2
-      )! +
+      (parentNode.children ?? [])
+        .filter((n) => childNodesSet.has(n.data))
+        .reduce(
+          (acc, n) =>
+            extremeFindingFunction(acc, n.x + (dir * (n.data.width ?? 0)) / 2),
+          0
+        ) +
       dir * SIBLING_LINK_STARTER_LENGTH
     );
   }

--- a/src/relatives-chart.ts
+++ b/src/relatives-chart.ts
@@ -2,7 +2,6 @@ import { getAncestorsTree } from './ancestor-chart';
 import { HierarchyNode, HierarchyPointNode } from 'd3-hierarchy';
 import { IdGenerator } from './id-generator';
 import { layOutDescendants } from './descendant-chart';
-import { max, min } from 'd3-array';
 import {
   Chart,
   ChartInfo,
@@ -234,16 +233,16 @@ export class RelativesChart<IndiT extends Indi, FamT extends Fam>
         } else if (data.left) {
           parentNode.x =
             nodeX +
-            min([
+            Math.min(
               nodeWidth / 2 -
                 parentData.width! / 2 -
                 spouseWidth / 2 -
                 H_SPACING,
               middleX,
-            ])!;
+            );
         } else {
           parentNode.x =
-            nodeX + max([parentData.width! / 2 - nodeWidth / 2, middleX])!;
+            nodeX + Math.max(parentData.width! / 2 - nodeWidth / 2, middleX);
         }
       }
 
@@ -291,14 +290,14 @@ export class RelativesChart<IndiT extends Indi, FamT extends Fam>
             nodeWidth / 2 + parentData.width! / 2 - spouseWidth + H_SPACING / 2;
         } else if (data.left) {
           parentNode.x =
-            nodeX + min([nodeWidth / 2 - parentData.width! / 2, middleX])!;
+            nodeX + Math.min(nodeWidth / 2 - parentData.width! / 2, middleX);
         } else {
           parentNode.x =
             nodeX +
-            max([
+            Math.max(
               parentData.width! / 2 - nodeWidth / 2 + indiWidth / 2 + H_SPACING,
               middleX,
-            ])!;
+            );
         }
       }
     });


### PR DESCRIPTION
The only features of d3-array that are used are min and max.
Both of these functions can be replicated using native code to reduce the number of dependencies and in some case improve performance.